### PR TITLE
빌드 대상 성경 목록 순번 세로 정렬 가운데로 변경

### DIFF
--- a/Bible2PPT/MainForm.Build.cs
+++ b/Bible2PPT/MainForm.Build.cs
@@ -263,7 +263,7 @@ namespace Bible2PPT
                     e.InheritedRowStyle.Font,
                     brush,
                     e.RowBounds.Location.X + biblesDataGridView.RowHeadersWidth - 3,
-                    e.RowBounds.Location.Y + 4,
+                    e.RowBounds.Location.Y + ((e.RowBounds.Height - e.InheritedRowStyle.Font.Height) / 2),
                     new StringFormat(StringFormatFlags.DirectionRightToLeft));
             }
         }


### PR DESCRIPTION
시스템 DPI가 높을 때 순번의 세로 정렬이 위로 치우쳐 있음.

세로 정렬을 가운데로 변경해서 보기 좋게 바꿈!