### PR TITLE
chore: 배포 자동화

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,59 @@
+name: Deployment
+# By listening release event, variables are set as:
+#
+# * `${{ github.ref }}`: '/refs/tags/v1.0.0'
+# * `${{ github.events }}`: See https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#release
+#
+# See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: self-hosted
+    
+    env:
+      PACKAGE_DIRECTORY: Bible2PPT/bin/Release 
+
+    steps:
+      - uses: microsoft/setup-msbuild@v1.0.0
+
+      - uses: actions/checkout@v2
+
+      - name: Parse semantic version
+        id: parse-version
+        uses: booxmedialtd/ws-action-parse-semver@v1
+        with:
+          input_string: ${{ github.ref }}
+          version_extractor_regex: '\/v(.*)$'
+
+      - name: Restore
+        run: msbuild -restore
+
+      - name: Build
+        run: msbuild -p:Version=${env:VERSION} -p:Configuration=Release
+        env:
+          VERSION: ${{ steps.parse-version.outputs.fullversion }}
+
+      - name: Package
+        id: package
+        run: |
+          Get-ChildItem | foreach {
+            $filename = Bible2PPT-${env:VERSION}-windows-${_}.zip
+            Compress-Archive -Path ${_}/* -DestinationPath ${filename}
+            Write-Host ::set-output name=filename::${filename}
+          }
+        env:
+          VERSION: ${{ steps.parse-version.outputs.fullversion }}
+        working-directory: ${{ env.PACKAGE_DIRECTORY }}
+      
+      - name: Upload
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.PACKAGE_DIRECTORY }}/${{ steps.package.outputs.filename }}
+          asset_name: ${{ steps.package.outputs.filename }}
+          asset_content_type: application/zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/Bible2PPT/Bible2PPT.csproj
+++ b/Bible2PPT/Bible2PPT.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net40</TargetFramework>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <RootNamespace>Bible2PPT</RootNamespace>
     <AssemblyName>Bible2PPT</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Bible2PPT/Bible2PPT.csproj
+++ b/Bible2PPT/Bible2PPT.csproj
@@ -12,8 +12,8 @@
     <Company>BloodCat</Company>
     <Product>Bible2PPT</Product>
     <Copyright>BloodCat 2015-2020</Copyright>
-    <Version>1.4.0</Version>
-    <FileVersion>1.4.0</FileVersion>
+    <Version Condition=" '$(Version)' == '' ">0.0.0</Version>
+    <FileVersion>$(Version)</FileVersion>
     <NeutralLanguage>ko-KR</NeutralLanguage>
 
     <NoWin32Manifest>true</NoWin32Manifest>


### PR DESCRIPTION
자동으로 버전을 입력해서 프로그램을 배포하는 workflow를 추가한다.

Office 프로그램과 연동을 위한 PIA가 빌드하면서 필요하므로, Office 설치를 완료한 self-hosted runner에서 작동한다.

MSBuild로 빌드하면 Client Profile을 찾지 못한다. Full Profile은 잘 빌드하므로 프로필을 변경해서 배포 자동화를 구현한다.