### PR TITLE
fix: 대상 프레임워크 .NET Framework 4.8로 변경

### DIFF
--- a/Bible2PPT/App.config
+++ b/Bible2PPT/App.config
@@ -1,20 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+  </startup>
 </configuration>

--- a/Bible2PPT/Bible2PPT.csproj
+++ b/Bible2PPT/Bible2PPT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <RootNamespace>Bible2PPT</RootNamespace>
     <AssemblyName>Bible2PPT</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>
@@ -18,7 +18,7 @@
 
     <NoWin32Manifest>true</NoWin32Manifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>
@@ -62,8 +63,6 @@
 
   <ItemGroup>
     <PackageReference Include="FontAwesome.Sharp" Version="5.13.0" />
-    <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="SQLite.CodeFirst" Version="1.6.0.30" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.113.1" />
   </ItemGroup>

--- a/Bible2PPT/Bibles/Sources/GodpeopleBible.cs
+++ b/Bible2PPT/Bibles/Sources/GodpeopleBible.cs
@@ -26,7 +26,7 @@ namespace Bible2PPT.Bibles.Sources
         }
 
         protected override Task<List<Bible>> GetBiblesOnlineAsync() =>
-            TaskEx.FromResult(new List<Bible>
+            Task.FromResult(new List<Bible>
             {
                 new Bible
                 {
@@ -57,7 +57,7 @@ namespace Bible2PPT.Bibles.Sources
             string.Join("", ENCODING.GetBytes(s).Select(b => $"%{b.ToString("X")}"));
 
         protected override Task<List<Chapter>> GetChaptersOnlineAsync(Book book) =>
-            TaskEx.FromResult(Enumerable.Range(1, book.ChapterCount)
+            Task.FromResult(Enumerable.Range(1, book.ChapterCount)
                 .Select(i => new Chapter
                 {
                     OnlineId = $"{i}",

--- a/Bible2PPT/Bibles/Sources/GoodtvBible.cs
+++ b/Bible2PPT/Bibles/Sources/GoodtvBible.cs
@@ -51,7 +51,7 @@ namespace Bible2PPT.Bibles.Sources
                     new KeyValuePair<string, string>("otnt", "2"),
                 })),
             };
-            var data = string.Join("", await TaskEx.WhenAll(tasks));
+            var data = string.Join("", await Task.WhenAll(tasks));
             var matches = Regex.Matches(data, @"""idx"":(\d+).+?""bible_name"":""(.+?)"".+?""max_jang"":(\d+)");
             return matches.Cast<Match>().Select(i => new Book
             {
@@ -62,7 +62,7 @@ namespace Bible2PPT.Bibles.Sources
         }
 
         protected override Task<List<Chapter>> GetChaptersOnlineAsync(Book book) =>
-            TaskEx.FromResult(Enumerable.Range(1, book.ChapterCount)
+            Task.FromResult(Enumerable.Range(1, book.ChapterCount)
                 .Select(i => new Chapter
                 {
                     OnlineId = $"{i}",

--- a/Bible2PPT/PPT/Builder.cs
+++ b/Bible2PPT/PPT/Builder.cs
@@ -38,14 +38,14 @@ namespace Bible2PPT.PPT
         RETRY:
             try
             {
-                return await TaskEx.WhenAll(bibles
+                return await Task.WhenAll(bibles
                     .Select(bible => bible.Source.GetBooksAsync(bible))
                     .ToList());
             }
             // 취소할 때까지 계속 재시도
             catch (OperationCanceledException) when (!token.IsCancellationRequested)
             {
-                await TaskEx.Delay(3000);
+                await Task.Delay(3000);
                 goto RETRY;
             }
         }
@@ -56,16 +56,16 @@ namespace Bible2PPT.PPT
             try
             {
                 // 해당 책이 없는 성경도 있으므로 주의해서 장 정보 가져오기
-                return await TaskEx.WhenAll(books
+                return await Task.WhenAll(books
                     .Select(book =>
                         book?.Source.GetChaptersAsync(book)
-                        ?? TaskEx.FromResult(new List<Chapter>()))
+                        ?? Task.FromResult(new List<Chapter>()))
                     .ToList());
             }
             // 취소할 때까지 계속 재시도
             catch (OperationCanceledException) when (!token.IsCancellationRequested)
             {
-                await TaskEx.Delay(3000);
+                await Task.Delay(3000);
                 goto RETRY;
             }
         }
@@ -133,16 +133,16 @@ namespace Bible2PPT.PPT
         RETRY:
             try
             {
-                return await TaskEx.WhenAll(chapters
+                return await Task.WhenAll(chapters
                     .Select(chapter =>
                         chapter?.Source.GetVersesAsync(chapter)
-                        ?? TaskEx.FromResult(new List<Verse>()))
+                        ?? Task.FromResult(new List<Verse>()))
                     .ToList());
             }
             // 취소할 때까지 계속 재시도
             catch (OperationCanceledException) when (!token.IsCancellationRequested)
             {
-                await TaskEx.Delay(3000);
+                await Task.Delay(3000);
                 goto RETRY;
             }
         }
@@ -239,7 +239,7 @@ namespace Bible2PPT.PPT
             var e = new JobProgressEventArgs(job, null, 0, queries.Count, 0, 0);
             OnJobProgress(e);
 
-            var produce = TaskEx.Run(async () =>
+            var produce = Task.Run(async () =>
             {
                 var eachBooks = await GetEachBooksAsync(job.Bibles, token);
 

--- a/Bible2PPT/PPT/JobManager.cs
+++ b/Bible2PPT/PPT/JobManager.cs
@@ -39,7 +39,7 @@ namespace Bible2PPT.PPT
             JobCancellations[job] = new CancellationTokenSource();
             OnJobQueued(new JobQueuedEventArgs(job));
 
-            TaskEx.Run(async () =>
+            Task.Run(async () =>
             {
                 var acquired = false;
                 try

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@
 
 ## 실행 요구 사항
 
-### .NET Framework 4 Client Profile 이상
-**성경2PPT**를 실행하는 데 필요한 프레임워크입니다. [여기](http://go.microsoft.com/fwlink/?LinkId=181012)에서 내려받아서 설치하시고, [여기](http://go.microsoft.com/fwlink/?linkid=221217)에서 업데이트를 설치하세요. ([관련 이슈](https://github.com/sunghwan2789/Bible2PPT/pull/21))
+### .NET Framework 4.8
+**성경2PPT**를 실행하는 데 필요한 프레임워크입니다. [여기](http://go.microsoft.com/fwlink/?LinkId=2085155)에서 내려받아서 설치하세요.
 
 ### Microsoft PowerPoint 2007 이상
 PPT를 만들고 보는 데 필요한 프로그램입니다. 프로그램 구성 요소로 *Office 공유 기능* - *Visual Basic for Applications*를 설치해야 합니다.


### PR DESCRIPTION
.NET Framework의 마지막 버전은 4.8이다. .NET 5가 내년이면 나오는데, 이제는 4.0 버전에 남을 이유가 없다.

BREAKING CHANGE: .NET Framework 4.8